### PR TITLE
Fix duplicate chunk return key

### DIFF
--- a/lib/facter/puppet_status_check.rb
+++ b/lib/facter/puppet_status_check.rb
@@ -21,7 +21,7 @@ Facter.add(:puppet_status_check, type: :aggregate) do
 
   chunk(:S0003) do
     # check for noop logic flip as false is the desired state
-    { AS003: !Puppet.settings['noop'] }
+    { S0003: !Puppet.settings['noop'] }
   end
 
   chunk(:S0004) do


### PR DESCRIPTION
The S0003 check for detecting 'noop' mode was returning the key AS003 which caused a conflict with the actual AS003 chunk resulting in this cryptic error:

> root@osp:/etc/telegraf# managed-osp facter -p puppet_status_check
> [2024-02-07 22:31:58.040994 ] ERROR Facter - Error while resolving custom fact fact='puppet_status_check', resolution='<anonymous>': can't modify frozen String: "Cannot merge true:TrueClass and false:FalseClass"